### PR TITLE
Show post word count and reading time

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,9 @@
         <h1><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
         <aside class="meta">
             {{ if and .Site.Params.dateformfull .Site.Params.dateform }}
-            Published on <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}">{{ .Date.Format .Site.Params.dateform }}.</time>
+            Published on <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}">{{ .Date.Format .Site.Params.dateform }}</time>
+            · {{ .WordCount }} {{ cond (eq .WordCount 1) "word" "words" }}
+            · {{ .ReadingTime }} min read.
             {{ end }}
         </aside>
     </header>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,8 +6,7 @@
         <aside class="meta">
             {{ if and .Site.Params.dateformfull .Site.Params.dateform }}
             Published on <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}">{{ .Date.Format .Site.Params.dateform }}</time>
-            · {{ .WordCount }} {{ cond (eq .WordCount 1) "word" "words" }}
-            · {{ .ReadingTime }} min read.
+            · {{ .WordCount }} {{ cond (eq .WordCount 1) "word" "words" }}.
             {{ end }}
         </aside>
     </header>


### PR DESCRIPTION
## Summary

- add each blog post's `.WordCount` after the published date
- keep the existing timestamp/date semantics intact

## Verification

```text
rm -rf build && nix develop --command bash -lc 'make -C scss && hugo --gc --minify'
Pages: 108
Static files: 12
Total in 83 ms
```

Checked generated posts:

- `/posts/1231/` renders: `Published on Nov 8, 2024 · 58 words.`
- `/posts/open-social-2025/` renders: `Published on Mar 31, 2025 · 2706 words.`
- verified `min read` is not present in the checked post metadata
