### PR TITLE
Improve blog post SEO metadata

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,8 +23,16 @@
     {{ $canonicalURL := .Permalink }}
     {{ with .Params.canonical }}{{ $canonicalURL = . }}{{ end }}
     {{ $imageURL := "" }}
-    {{ with .Params.images }}{{ with index . 0 }}{{ $imageURL = . | absURL }}{{ end }}{{ end }}
-    {{ if and (not $imageURL) .Params.image }}{{ $imageURL = .Params.image | absURL }}{{ end }}
+    {{ $imagePath := "" }}
+    {{ with .Params.images }}{{ with index . 0 }}{{ $imagePath = . }}{{ end }}{{ end }}
+    {{ if and (not $imagePath) .Params.image }}{{ $imagePath = .Params.image }}{{ end }}
+    {{ with $imagePath -}}
+        {{ with $.Resources.GetMatch . -}}
+            {{ $imageURL = .Permalink }}
+        {{ else -}}
+            {{ $imageURL = . | absURL }}
+        {{ end -}}
+    {{ end -}}
     {{ block "extra_head" . }}{{ end }}
     <link rel="canonical" href="{{ $canonicalURL }}">
     {{ with $pageDescription -}}
@@ -34,7 +42,7 @@
     <meta property="og:title" content="{{ $pageTitle }}">
     {{ with $pageDescription }}<meta property="og:description" content="{{ . }}">{{ end }}
     <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
-    <meta property="og:url" content="{{ .Permalink }}">
+    <meta property="og:url" content="{{ $canonicalURL }}">
     {{ with $imageURL }}<meta property="og:image" content="{{ . }}">{{ end }}
     <meta name="twitter:site" content="@shazow">
     <meta name="twitter:creator" content="@shazow">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,21 +18,30 @@
     <link rel="preload" href="{{ $goudyRegular.RelPermalink }}" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="{{ $goudyItalic.RelPermalink }}" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="{{ $fontCSS.RelPermalink }}" integrity="{{ $fontCSS.Data.Integrity }}">
+    {{ $pageDescription := partial "seo-description.html" . }}
+    {{ $pageTitle := cond .IsHome .Site.Title (printf "%s | shazow.net" .Title) }}
+    {{ $canonicalURL := .Permalink }}
+    {{ with .Params.canonical }}{{ $canonicalURL = . }}{{ end }}
+    {{ $imageURL := "" }}
+    {{ with .Params.images }}{{ with index . 0 }}{{ $imageURL = . | absURL }}{{ end }}{{ end }}
+    {{ if and (not $imageURL) .Params.image }}{{ $imageURL = .Params.image | absURL }}{{ end }}
     {{ block "extra_head" . }}{{ end }}
-    {{ if .IsHome -}}
-    <meta name="description" content="{{ .Site.Params.description | htmlEscape }}">
+    <link rel="canonical" href="{{ $canonicalURL }}">
+    {{ with $pageDescription -}}
+    <meta name="description" content="{{ . }}">
     {{ end -}}
+    <meta property="og:site_name" content="{{ .Site.Title }}">
+    <meta property="og:title" content="{{ $pageTitle }}">
+    {{ with $pageDescription }}<meta property="og:description" content="{{ . }}">{{ end }}
+    <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
+    <meta property="og:url" content="{{ .Permalink }}">
+    {{ with $imageURL }}<meta property="og:image" content="{{ . }}">{{ end }}
     <meta name="twitter:site" content="@shazow">
     <meta name="twitter:creator" content="@shazow">
-    {{ if .IsPage -}}
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="{{ .Title }}" />
-    <meta name="twitter:description" content="{{ .Summary }}" />
-    {{ if .Params.image }}<meta name="twitter:image" content="{{ .Permalink }}{{ .Params.image }}" />{{ end }}
-    {{ else -}}
-    <meta name="twitter:title" content="{{ .Site.Title }}" />
-    <meta name="twitter:description" content="{{ .Site.Params.description | htmlEscape }}" />
-    {{ end }}
+    <meta name="twitter:card" content="{{ if $imageURL }}summary_large_image{{ else }}summary{{ end }}">
+    <meta name="twitter:title" content="{{ $pageTitle }}">
+    {{ with $pageDescription }}<meta name="twitter:description" content="{{ . }}">{{ end }}
+    {{ with $imageURL }}<meta name="twitter:image" content="{{ . }}">{{ end }}
 </head>
 
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "body" }}
-<main>
+<div>
     <article>
         <header>
             <h1>{{.Title}}</h1>
@@ -35,5 +35,5 @@
         </div>
     </article>
 
-</main>
+</div>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,6 +39,8 @@
     {{ range .Params.tags }}<meta property="article:tag" content="{{ . }}">
     {{ end -}}
     {{ $pageDescription := partial "seo-description.html" . -}}
+    {{ $canonicalURL := .Permalink -}}
+    {{ with .Params.canonical }}{{ $canonicalURL = . }}{{ end -}}
     {{ $schema := dict
         "@context" "https://schema.org"
         "@type" "BlogPosting"
@@ -46,8 +48,8 @@
         "description" $pageDescription
         "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
         "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
-        "url" .Permalink
-        "mainEntityOfPage" .Permalink
+        "url" $canonicalURL
+        "mainEntityOfPage" $canonicalURL
         "author" (dict "@type" "Person" "name" .Site.Params.author "url" .Site.BaseURL)
         "publisher" (dict "@type" "Person" "name" .Site.Params.author "url" .Site.BaseURL)
     -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -34,9 +34,24 @@
 {{ define "title" }}{{ .Title }} | shazow.net{{ end }}
 {{ define "extra_head" -}}
     <link href="/css/syntax.css" media="screen" rel="stylesheet" type="text/css" />
-    {{ if .Params.canonical -}}
-    <link rel="canonical" href="{{ .Params.canonical }}" />
-    {{ end }}
+    <meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
+    <meta property="article:modified_time" content="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}">
+    {{ range .Params.tags }}<meta property="article:tag" content="{{ . }}">
+    {{ end -}}
+    {{ $pageDescription := partial "seo-description.html" . -}}
+    {{ $schema := dict
+        "@context" "https://schema.org"
+        "@type" "BlogPosting"
+        "headline" .Title
+        "description" $pageDescription
+        "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
+        "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+        "url" .Permalink
+        "mainEntityOfPage" .Permalink
+        "author" (dict "@type" "Person" "name" .Site.Params.author "url" .Site.BaseURL)
+        "publisher" (dict "@type" "Person" "name" .Site.Params.author "url" .Site.BaseURL)
+    -}}
+    <script type="application/ld+json">{{ jsonify $schema | safeJS }}</script>
 {{ end }}
 {{ define "tail" -}}
     {{ $js := resources.Get "js/post.js" | fingerprint }}

--- a/layouts/partials/seo-description.html
+++ b/layouts/partials/seo-description.html
@@ -1,0 +1,15 @@
+{{- $description := "" -}}
+{{- if .Description -}}
+    {{- $description = .Description -}}
+{{- else if .IsHome -}}
+    {{- $description = .Site.Params.description -}}
+{{- else if .IsPage -}}
+    {{- $description = .Summary -}}
+{{- else if .Title -}}
+    {{- $description = printf "%s on %s" .Title .Site.Title -}}
+{{- end -}}
+{{- $description = $description | plainify | htmlUnescape | replaceRE "\\s+" " " | strings.TrimSpace | truncate 160 -}}
+{{- if and (not $description) .Title -}}
+    {{- $description = printf "%s on %s" .Title .Site.Title | truncate 160 -}}
+{{- end -}}
+{{- return $description -}}

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,29 @@
+# As a condition of accessing this website, you agree to abide by the following
+# content signals:
+
+# (a)  If a content-signal = yes, you may collect content for the corresponding
+#      use.
+# (b)  If a content-signal = no, you may not collect content for the
+#      corresponding use.
+# (c)  If the website operator does not include a content signal for a
+#      corresponding use, the website operator neither grants nor restricts
+#      permission via content signal with respect to the corresponding use.
+
+# The content signals and their meanings are:
+
+# search:   building a search index and providing search results (e.g., returning
+#           hyperlinks and short excerpts from your website's contents). Search does not
+#           include providing AI-generated search summaries.
+# ai-input: inputting content into one or more AI models (e.g., retrieval
+#           augmented generation, grounding, or other real-time taking of content for
+#           generative AI search answers).
+# ai-train: training or fine-tuning AI models.
+
+# ANY RESTRICTIONS EXPRESSED VIA CONTENT SIGNALS ARE EXPRESS RESERVATIONS OF
+# RIGHTS UNDER ARTICLE 4 OF THE EUROPEAN UNION DIRECTIVE 2019/790 ON COPYRIGHT
+# AND RELATED RIGHTS IN THE DIGITAL SINGLE MARKET.
+
+User-agent: *
+Allow: /
+
+Sitemap: https://shazow.net/sitemap.xml

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,28 +1,3 @@
-# As a condition of accessing this website, you agree to abide by the following
-# content signals:
-
-# (a)  If a content-signal = yes, you may collect content for the corresponding
-#      use.
-# (b)  If a content-signal = no, you may not collect content for the
-#      corresponding use.
-# (c)  If the website operator does not include a content signal for a
-#      corresponding use, the website operator neither grants nor restricts
-#      permission via content signal with respect to the corresponding use.
-
-# The content signals and their meanings are:
-
-# search:   building a search index and providing search results (e.g., returning
-#           hyperlinks and short excerpts from your website's contents). Search does not
-#           include providing AI-generated search summaries.
-# ai-input: inputting content into one or more AI models (e.g., retrieval
-#           augmented generation, grounding, or other real-time taking of content for
-#           generative AI search answers).
-# ai-train: training or fine-tuning AI models.
-
-# ANY RESTRICTIONS EXPRESSED VIA CONTENT SIGNALS ARE EXPRESS RESERVATIONS OF
-# RIGHTS UNDER ARTICLE 4 OF THE EUROPEAN UNION DIRECTIVE 2019/790 ON COPYRIGHT
-# AND RELATED RIGHTS IN THE DIGITAL SINGLE MARKET.
-
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
## Summary

- add generated meta descriptions to blog posts, taxonomy/list pages, and other non-home pages
- add canonical URLs, Open Graph metadata, and cleaned-up Twitter card metadata from one shared page-description helper
- add BlogPosting JSON-LD to post pages with published/modified dates, author, URL, and description
- add a minimal repo-owned `robots.txt` with `Allow: /` and a `Sitemap:` pointer
- remove the extra nested `<main>` from list pages now that the base template owns the page landmark

## SEO review findings

Before this PR, generated blog post pages had:

| Check | Before |
|---|---:|
| Blog post pages checked | 37 |
| Missing `<meta name="description">` | 37 |
| Missing canonical URL | 37 |
| Missing Open Graph title/description/url | 37 |
| Missing BlogPosting JSON-LD | 37 |
| `robots.txt` sitemap pointer | missing from live response |

The existing Twitter summaries were present for most posts, but they used raw `.Summary` and were not mirrored into standard search/snippet metadata.

## Verification

Build:

```text
rm -rf build && nix develop --command bash -lc 'make -C scss && hugo --gc --minify'
Pages: 108
Static files: 13
Total in 270 ms
```

Generated-output audit after the change:

| Check | After |
|---|---:|
| Blog post pages checked | 37 |
| Missing `<meta name="description">` | 0 |
| Bad/missing canonical URL count | 0 |
| Missing Open Graph title/description/url | 0 |
| Valid `BlogPosting` JSON-LD blocks | 37 |
| Canonical / `og:url` / JSON-LD URL consistency issues | 0 |
| Page-bundle `og:image` target exists for image-post sample | yes |
| Homepage/list/tag `<main>` count | 1 each |
| Minimal `robots.txt` includes `Sitemap: https://shazow.net/sitemap.xml` | yes |

Local Lighthouse 13.4.0 desktop:

| Page | SEO |
|---|---:|
| `/` | 100 |
| `/posts/decentralization/` | 100 |
| `/posts/github-issues-as-a-hugo-frontend/` | 100 |

Browser smoke check on `/posts/decentralization/`:

```json
{
  "title": "Decentralization | shazow.net",
  "description": "As technological advancements march on, we’re having a lot of very important conversations about what we want out of the platforms we use day to day. We often …",
  "canonical": "https://shazow.net/posts/decentralization/",
  "ogType": "article",
  "jsonLdType": "BlogPosting",
  "mainCount": 1
}
```

No console messages were reported during the browser smoke check.

## Self-review follow-up

A clean-context Hugo/SEO self-review found and this PR now fixes:

- page-bundle-relative `image` params incorrectly becoming root-relative `og:image` / `twitter:image` URLs
- canonical override values not being reused consistently for `og:url` and BlogPosting `url` / `mainEntityOfPage`

The self-review also noted two unrelated existing cleanups outside this SEO PR: Markdown image render-hook escaping style and trailing whitespace in the pre-existing font license file. I left those out to keep this PR focused.
