### PR TITLE
Skip custom font loading on post pages

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,12 +12,14 @@
 
     <link rel="alternate" type="application/rss+xml" title="RSS Feed shazow.net" href="/index.xml" />
 
+    {{ if not .IsPage -}}
     {{ $goudyRegular := resources.Get "fonts/ofl-sorts-mill-goudy-tt-regular.woff2" | fingerprint }}
     {{ $goudyItalic := resources.Get "fonts/ofl-sorts-mill-goudy-tt-italic.woff2" | fingerprint }}
     {{ $fontCSS := printf "@font-face {\n  font-family: 'OFL Sorts Mill Goudy TT';\n  font-style: normal;\n  font-weight: 400;\n  font-display: swap;\n  src: url('%s') format('woff2');\n  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;\n}\n@font-face {\n  font-family: 'OFL Sorts Mill Goudy TT';\n  font-style: italic;\n  font-weight: 400;\n  font-display: swap;\n  src: url('%s') format('woff2');\n  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;\n}\n" $goudyRegular.RelPermalink $goudyItalic.RelPermalink | resources.FromString "css/fonts.css" | fingerprint }}
     <link rel="preload" href="{{ $goudyRegular.RelPermalink }}" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="{{ $goudyItalic.RelPermalink }}" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="{{ $fontCSS.RelPermalink }}" integrity="{{ $fontCSS.Data.Integrity }}">
+    {{ end -}}
     {{ $pageDescription := partial "seo-description.html" . }}
     {{ $pageTitle := cond .IsHome .Site.Title (printf "%s | shazow.net" .Title) }}
     {{ $canonicalURL := .Permalink }}


### PR DESCRIPTION
## Summary

- confirm post pages do not render with the self-hosted Goudy font
- skip Goudy font preloads and `fonts.css` on `.IsPage` pages
- keep eager/preloaded Goudy loading on homepage, post list, tag/category/list pages where the global heading/section styles still use it

## Why

The post layout overrides typography inside `.post`:

- post title/headings: `Lucida Grande`, `Lucida Sans Unicode`, `Lucida Sans`, Geneva, Arial, sans-serif
- post body: `PT Serif`, Georgia, Cambria, Times, serif

A browser check on `/posts/decentralization/` found `0` elements using `OFL Sorts Mill Goudy TT`, but the page still downloaded:

- `fonts.css`
- regular Goudy WOFF2
- italic Goudy WOFF2

This PR avoids those requests for post pages. I chose not to prefetch/async-load the font on posts because the posts do not need it for rendering; loading it later would still consume bandwidth on the pages we are trying to slim down. The font remains eagerly loaded on non-post pages.

## Verification

Build:

```text
rm -rf build && nix develop --command bash -lc 'make -C scss && hugo --gc --minify'
Pages: 108
Static files: 13
Total in 265 ms
```

Generated HTML checks:

| Page | `fonts.css` linked | font preloads | WOFF2 refs |
|---|---:|---:|---:|
| `/` | yes | 2 | 2 |
| `/posts/decentralization/` | no | 0 | 0 |
| `/posts/` | yes | 2 | 2 |

Browser checks:

| Page | Result |
|---|---|
| `/posts/decentralization/` | no font stylesheet, no font preloads, no Goudy-rendered elements, stylesheet/font network requests dropped to `base.css` + `syntax.css` only |
| `/` | keeps `fonts.css`, both font preloads, both WOFF2 requests, title font remains `OFL Sorts Mill Goudy TT`, title width remains `348.609375px` |

Local Lighthouse 13.4.0 desktop on `/posts/decentralization/` after the change:

| Category | Score |
|---|---:|
| Performance | 100 |
| Accessibility | 100 |
| Best Practices | 100 |
| SEO | 100 |
| Agentic Browsing | 100 |

Selected metrics:

- total byte weight: `38 KiB`
- FCP: `0.3 s`
- LCP: `0.3 s`
- Speed Index: `0.3 s`
- CLS: `0`
